### PR TITLE
fix store.send syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ const store = useToggleStore()
 </script>
 
 <template>
-  <button @click="store.send('TOGGLE')">
+  <button @click="store.send({ type: 'TOGGLE' })">
     {{ store.state.value === 'inactive'
       ? 'Click to activate'
       : 'Active! Click to deactivate' }}


### PR DESCRIPTION
In xstate v5 syntax `store.send('TOGGLE')` is not valid, it should be `store.send({ type: 'TOGGLE' })`